### PR TITLE
Update the debian/ubuntu build dependency on openjdk.

### DIFF
--- a/wsgate/debian/control
+++ b/wsgate/debian/control
@@ -2,7 +2,7 @@ Source: wsgate
 Section: net
 Priority: extra
 Maintainer: Fritz Elfert <wsgate@fritz-elfert.de>
-Build-Depends: debhelper (>= 8.0.0), autotools-dev, g++, libehs-dev, libfreerdp-dev, libssl-dev, libdw-dev, libboost-dev, libboost-regex-dev, libboost-filesystem-dev, libboost-program-options-dev, libboost-system-dev, libpcre3-dev, libpng-dev, libtool, doxygen, graphviz, openjdk-6-jre-headless
+Build-Depends: debhelper (>= 8.0.0), autotools-dev, g++, libehs-dev, libfreerdp-dev, libssl-dev, libdw-dev, libboost-dev, libboost-regex-dev, libboost-filesystem-dev, libboost-program-options-dev, libboost-system-dev, libpcre3-dev, libpng-dev, libtool, doxygen, graphviz, openjdk-6-jre-headless | openjdk-7-jre-headless | openjdk-8-jre-headless
 Standards-Version: 3.9.2
 Homepage: https://github.com/FreeRDP/FreeRDP-WebConnect
 #Vcs-Git: git://git.debian.org/collab-maint/wsgate.git


### PR DESCRIPTION
On Debian GNU/Linux Sid (unstable), the package is named <code>openjdk-8-jre-headless</code>.
