### PR TITLE
Add build depend on "libcpprest-dev" (Casablanca dev package).

### DIFF
--- a/wsgate/debian/control
+++ b/wsgate/debian/control
@@ -2,7 +2,7 @@ Source: wsgate
 Section: net
 Priority: extra
 Maintainer: Fritz Elfert <wsgate@fritz-elfert.de>
-Build-Depends: debhelper (>= 8.0.0), autotools-dev, g++, libehs-dev, libfreerdp-dev, libssl-dev, libdw-dev, libboost-dev, libboost-regex-dev, libboost-filesystem-dev, libboost-program-options-dev, libboost-system-dev, libpcre3-dev, libpng-dev, libtool, doxygen, graphviz, openjdk-6-jre-headless
+Build-Depends: debhelper (>= 8.0.0), autotools-dev, g++, libehs-dev, libfreerdp-dev, libssl-dev, libdw-dev, libboost-dev, libboost-regex-dev, libboost-filesystem-dev, libboost-program-options-dev, libboost-system-dev, libpcre3-dev, libpng-dev, libtool, doxygen, graphviz, openjdk-6-jre-headless, libcpprest-dev
 Standards-Version: 3.9.2
 Homepage: https://github.com/FreeRDP/FreeRDP-WebConnect
 #Vcs-Git: git://git.debian.org/collab-maint/wsgate.git


### PR DESCRIPTION
Avoids the following build problem:

```
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
CASABLANCA_INCLUDE_DIR (ADVANCED)
   used as include directory in directory /usr/local/src/FreeRDP-WebConnect/wsgate
   used as include directory in directory /usr/local/src/FreeRDP-WebConnect/wsgate
   used as include directory in directory /usr/local/src/FreeRDP-WebConnect/wsgate
   used as include directory in directory /usr/local/src/FreeRDP-WebConnect/wsgate
LIB_CASABLANCA (ADVANCED)
    linked by target "wsgate" in directory /usr/local/src/FreeRDP-WebConnect/wsgate
```