### PR TITLE
#143 added regex to replace double port ref

### DIFF
--- a/wsgate/webroot/index-debug.html
+++ b/wsgate/webroot/index-debug.html
@@ -127,7 +127,7 @@
 
             function RDPStart(uri, title){
                 if(uri === undefined){
-                    uri = wsBase;
+                    uri = wsBase.replace(/(\:\d+)(\:\d+)/gi, "$1");
                 }
                 if(title === undefined){
                     title = "FreeRDP WebConnect: connected to " + $('rdphost').value.trim();


### PR DESCRIPTION
Regex to capture and replace double-port inclusions with single ref. Will not affect standard port (80, 443) instances.